### PR TITLE
Reusable release workflow

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,31 @@
+name: notify-slack
+run-name: Notify Slack for ${{ inputs.PACKAGE_NAME }} ${{ inputs.VERSION }} release
+
+on:
+  workflow_call:
+    inputs:
+      PACKAGE_NAME:
+        type: string
+        description: The name of the package that was released
+        required: true
+      VERSION:
+        type: string
+        description: The version that was released
+        required: true
+      REPOSITORY:
+        type: string
+        description: The repository name
+        required: true
+    secrets:
+      SLACK_URL_MISSION_CONTROL:
+        description: The URL of the Slack channel to send the release notification to
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: notify slack
+        run: |
+          export DATA="{\"text\":\"Release notification - ${{ inputs.PACKAGE_NAME }} ${{ inputs.VERSION }} (see <https://github.com/nextmv-io/${{ inputs.REPOSITORY }}/releases/${{ inputs.VERSION }}|release notes>)\"}"
+          curl -X POST -H 'Content-type: application/json' --data "$DATA" ${{ secrets.SLACK_URL_MISSION_CONTROL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,207 @@
+name: release
+run-name: Release ${{ inputs.BRANCH }} by @${{ github.actor }} from ${{ inputs.BRANCH }}
+
+on:
+  workflow_call:
+    inputs:
+      BRANCH:
+        type: string
+        description: The branch that triggered the workflow
+        required: true
+      REPOSITORY:
+        type: string
+        description: The repository name
+        required: true
+      ENVIRONMENT_NAME:
+        type: string
+        description: The environment to release to
+        required: true
+      ENVIRONMENT_URL:
+        type: string
+        description: The URL of the environment to release to
+        required: true
+      LANGUAGE:
+        type: string
+        description: The language of the repository
+        required: true
+      PACKAGE_NAME:
+        type: string
+        description: The name of the package to release
+        required: true
+      PACKAGE_LOCATION:
+        type: string
+        description: The location of the package to release
+        required: true
+      VERSION_FILE:
+        type: string
+        description: The file that contains the version
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      RELEASE_NEEDED: true
+      IS_DEV_TAG: true
+      PYTHON_VERSION: 3.13
+      VERSION: ""
+      MAIN_BRANCH: develop
+    permissions:
+      contents: write # Required for creating releases and tags
+      id-token: write # This is required for trusted publishing to PyPI
+    environment:
+      name: ${{ inputs.ENVIRONMENT_NAME }}
+      url: ${{ inputs.ENVIRONMENT_URL }}
+    steps:
+      - name: configure git with the bot credentials
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.NEXTMVBOT_SSH_KEY }}"
+
+          echo "${{ secrets.NEXTMVBOT_SIGNING_KEY }}" > ~/.ssh/signing.key
+          chmod 600 ~/.ssh/signing.key
+
+          git config --global user.name "nextmv-bot"
+          git config --global user.email "tech+gh-nextmv-bot@nextmv.io"
+          git config --global gpg.format ssh
+          git config --global user.signingkey ~/.ssh/signing.key
+
+          git clone git@github.com:nextmv-io/${{ inputs.REPOSITORY }}.git
+          cd ${{ inputs.REPOSITORY }}
+          git switch ${{ inputs.BRANCH }}
+
+      - name: python - set up
+        if: ${{ inputs.LANGUAGE == 'python' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: python - install dependencies
+        if: ${{ inputs.LANGUAGE == 'python' }}
+        run: |
+          pip install --upgrade pip
+          pip install build hatch
+
+      - name: set filters file for changed paths
+        run: |
+          FILTERS_FILE="./.github/filters.yml"
+          touch $FILTERS_FILE
+          echo "${{ inputs.PACKAGE_NAME }}:
+            - '${{ inputs.PACKAGE_LOCATION }}/${{ inputs.VERSION_FILE }}'" >> $FILTERS_FILE
+
+          echo "Successfully created filters and wrote them to ${FILTERS_FILE}"
+          cat $FILTERS_FILE
+        working-directory: ./${{ inputs.REPOSITORY }}
+
+      - name: filter changed directories
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: .github/filters.yml
+          working-directory: ./${{ inputs.REPOSITORY }}
+
+      - name: go - set the version
+        if: ${{ inputs.LANGUAGE == 'go' }}
+        run: |
+          export VERSION="$(cat VERSION)"
+          echo "This is the version"
+          echo $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+        working-directory: ./${{ inputs.REPOSITORY }}
+
+      - name: python - set the version
+        if: ${{ inputs.LANGUAGE == 'python' }}
+        run: |
+          export VERSION="v$(hatch version)"
+          echo "This is the version"
+          echo $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+        working-directory: ./${{ inputs.REPOSITORY }}
+
+      - name: set IS_DEV_TAG flag
+        run: |
+          if [[ "$VERSION" =~ (alpha|beta|rc|dev|pre|a|b) ]]; then
+            echo "IS_DEV_TAG=true" >> $GITHUB_ENV
+            echo "Detected dev tag: $VERSION"
+            exit 0
+          fi
+
+          echo "IS_DEV_TAG=false" >> $GITHUB_ENV
+          echo "Detected stable tag: $VERSION"
+
+      - name: determine if release is needed
+        run: |
+          # If no changes are detected on the version file, we don't release.
+          CHANGES=${{ steps.filter.outputs.changes }}
+          echo "CHANGES: $CHANGES"
+          if [ "$CHANGES" = "[]" ]; then
+            echo "No changes detected"
+            echo "RELEASE_NEEDED=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # If a stable tag is detected on a feature branch, we don't release.
+          if [ "${{ env.IS_DEV_TAG }}" = "false" ] && [ "${{ inputs.BRANCH }}" != "${{ env.MAIN_BRANCH }}" ]; then
+            echo "Stable tag detected on feature branch"
+            echo "RELEASE_NEEDED=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # If a dev tag is detected on the main branch, we don't release.
+          if [ "${{ env.IS_DEV_TAG }}" = "true" ] && [ "${{ inputs.BRANCH }}" = "${{ env.MAIN_BRANCH }}" ]; then
+            echo "Dev tag detected on main branch"
+            echo "RELEASE_NEEDED=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # Check if the version tag already exists
+          if git show-ref --tags --verify --quiet "refs/tags/${{ env.VERSION }}"; then
+            echo "Version tag ${{ env.VERSION }} already exists"
+            echo "RELEASE_NEEDED=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          echo "RELEASE_NEEDED=true" >> $GITHUB_ENV
+          echo "Release is needed"
+
+      - name: tag new version
+        if: ${{ env.RELEASE_NEEDED == 'true' }}
+        run: |
+          git tag ${{ env.VERSION }}
+          git push origin ${{ env.VERSION }}
+        working-directory: ./${{ inputs.REPOSITORY }}
+
+      - name: create release
+        if: ${{ env.RELEASE_NEEDED == 'true' }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [ ${{ env.IS_DEV_TAG }} = true ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create $VERSION \
+          --verify-tag \
+          --generate-notes \
+          --title $VERSION $PRERELEASE_FLAG
+        working-directory: ./${{ inputs.REPOSITORY }}
+
+      - name: python - build binary wheel and source tarball
+        if: ${{ env.RELEASE_NEEDED == 'true' && inputs.LANGUAGE == 'python' }}
+        run: python -m build
+        working-directory: ./${{ inputs.REPOSITORY }}/${{ inputs.PACKAGE_LOCATION }}
+
+      - name: python - publish package distributions to PyPI
+        if: ${{ env.RELEASE_NEEDED == 'true' && inputs.LANGUAGE == 'python' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./${{ inputs.REPOSITORY }}/${{ inputs.PACKAGE_LOCATION }}/dist
+
+      - name: notify slack
+        if: ${{ env.RELEASE_NEEDED == 'true' && env.IS_DEV_TAG == 'false' }}
+        run: |
+          export DATA="{\"text\":\"Release notification - ${{ inputs.PACKAGE_NAME }} ${{ env.VERSION }} (see <https://github.com/nextmv-io/${{ inputs.REPOSITORY }}/releases/${{ env.VERSION }}|release notes>)\"}"
+          curl -X POST -H 'Content-type: application/json' --data "$DATA" ${{ secrets.SLACK_URL_MISSION_CONTROL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           FILTERS_FILE="./.github/filters.yml"
           touch $FILTERS_FILE
           echo "${{ inputs.PACKAGE_NAME }}:
-            - '${{ inputs.PACKAGE_LOCATION }}/${{ inputs.VERSION_FILE }}'" >> $FILTERS_FILE
+            - '${{ inputs.PACKAGE_LOCATION }}/${{ inputs.PACKAGE_NAME }}/${{ inputs.VERSION_FILE }}'" >> $FILTERS_FILE
 
           echo "Successfully created filters and wrote them to ${FILTERS_FILE}"
           cat $FILTERS_FILE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,16 @@ on:
         type: string
         description: The file that contains the version
         required: true
+    secrets:
+      SLACK_URL_MISSION_CONTROL:
+        description: The URL of the Slack channel to send the release notification to
+        required: true
+      NEXTMVBOT_SSH_KEY:
+        description: The SSH key for the nextmv-bot user
+        required: true
+      NEXTMVBOT_SIGNING_KEY:
+        description: The signing key for the nextmv-bot user
+        required: true
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,17 +203,6 @@ jobs:
           --title $VERSION $PRERELEASE_FLAG
         working-directory: ./${{ inputs.REPOSITORY }}
 
-      - name: python - build binary wheel and source tarball
-        if: ${{ env.RELEASE_NEEDED == 'true' && inputs.LANGUAGE == 'python' }}
-        run: python -m build
-        working-directory: ./${{ inputs.REPOSITORY }}/${{ inputs.PACKAGE_LOCATION }}
-
-      - name: python - publish package distributions to PyPI
-        if: ${{ env.RELEASE_NEEDED == 'true' && inputs.LANGUAGE == 'python' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: ./${{ inputs.REPOSITORY }}/${{ inputs.PACKAGE_LOCATION }}/dist
-
       - name: set job outputs
         id: set-outputs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,6 @@ on:
         type: string
         description: The repository name
         required: true
-      ENVIRONMENT_NAME:
-        type: string
-        description: The environment to release to
-        required: true
-      ENVIRONMENT_URL:
-        type: string
-        description: The URL of the environment to release to
-        required: true
       LANGUAGE:
         type: string
         description: The language of the repository
@@ -75,9 +67,6 @@ jobs:
     permissions:
       contents: write # Required for creating releases and tags
       id-token: write # This is required for trusted publishing to PyPI
-    environment:
-      name: ${{ inputs.ENVIRONMENT_NAME }}
-      url: ${{ inputs.ENVIRONMENT_URL }}
     steps:
       - name: configure git with the bot credentials
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,16 @@ on:
         type: string
         description: The file that contains the version
         required: true
+    outputs:
+      VERSION:
+        description: The version of the package to release
+        value: ${{ jobs.release.outputs.VERSION }}
+      RELEASE_NEEDED:
+        description: Whether the release is needed
+        value: ${{ jobs.release.outputs.RELEASE_NEEDED }}
+      SHOULD_NOTIFY_SLACK:
+        description: Whether the release should notify slack
+        value: ${{ jobs.release.outputs.SHOULD_NOTIFY_SLACK }}
     secrets:
       SLACK_URL_MISSION_CONTROL:
         description: The URL of the Slack channel to send the release notification to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     outputs:
-      SHOULD_NOTIFY_SLACK: ${{ steps.set-outputs.outputs.SHOULD_NOTIFY_SLACK }}
       VERSION: ${{ steps.set-outputs.outputs.VERSION }}
+      RELEASE_NEEDED: ${{ steps.set-outputs.outputs.RELEASE_NEEDED }}
+      SHOULD_NOTIFY_SLACK: ${{ steps.set-outputs.outputs.SHOULD_NOTIFY_SLACK }}
     env:
       GH_TOKEN: ${{ github.token }}
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
@@ -207,6 +208,7 @@ jobs:
         id: set-outputs
         run: |
           echo "VERSION=${{ env.VERSION }}" >> $GITHUB_OUTPUT
+          echo "RELEASE_NEEDED=${{ env.RELEASE_NEEDED }}" >> $GITHUB_OUTPUT
 
           # Set SHOULD_NOTIFY_SLACK based on release needed and stable version
           if [ "${{ env.RELEASE_NEEDED }}" = "true" ] && [ "${{ env.IS_DEV_TAG }}" = "false" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: release
-run-name: Release ${{ inputs.BRANCH }} by @${{ github.actor }} from ${{ inputs.BRANCH }}
+run-name: Release ${{ inputs.PACKAGE_NAME }} by @${{ github.actor }} from ${{ inputs.REPOSITORY }}/${{ inputs.BRANCH }}
 
 on:
   workflow_call:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,7 @@ jobs:
 
           echo "RELEASE_NEEDED=true" >> $GITHUB_ENV
           echo "Release is needed"
+        working-directory: ./${{ inputs.REPOSITORY }}
 
       - name: tag new version
         if: ${{ env.RELEASE_NEEDED == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      SHOULD_NOTIFY_SLACK: ${{ steps.set-outputs.outputs.SHOULD_NOTIFY_SLACK }}
+      VERSION: ${{ steps.set-outputs.outputs.VERSION }}
     env:
       GH_TOKEN: ${{ github.token }}
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
@@ -211,8 +214,16 @@ jobs:
         with:
           packages-dir: ./${{ inputs.REPOSITORY }}/${{ inputs.PACKAGE_LOCATION }}/dist
 
-      - name: notify slack
-        if: ${{ env.RELEASE_NEEDED == 'true' && env.IS_DEV_TAG == 'false' }}
+      - name: set job outputs
+        id: set-outputs
         run: |
-          export DATA="{\"text\":\"Release notification - ${{ inputs.PACKAGE_NAME }} ${{ env.VERSION }} (see <https://github.com/nextmv-io/${{ inputs.REPOSITORY }}/releases/${{ env.VERSION }}|release notes>)\"}"
-          curl -X POST -H 'Content-type: application/json' --data "$DATA" ${{ secrets.SLACK_URL_MISSION_CONTROL }}
+          echo "VERSION=${{ env.VERSION }}" >> $GITHUB_OUTPUT
+
+          # Set SHOULD_NOTIFY_SLACK based on release needed and stable version
+          if [ "${{ env.RELEASE_NEEDED }}" = "true" ] && [ "${{ env.IS_DEV_TAG }}" = "false" ]; then
+            echo "We need to notify slack"
+            echo "SHOULD_NOTIFY_SLACK=true" >> $GITHUB_OUTPUT
+          else
+            echo "We don't need to notify slack"
+            echo "SHOULD_NOTIFY_SLACK=false" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,6 @@ jobs:
       MAIN_BRANCH: develop
     permissions:
       contents: write # Required for creating releases and tags
-      id-token: write # This is required for trusted publishing to PyPI
     steps:
       - name: configure git with the bot credentials
         run: |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,195 @@
-# release
-Resources for releasing Nextmv applications
+# Release Workflow
+
+A reusable GitHub Actions workflow for automated package releases across Nextmv
+repositories.
+
+## Overview
+
+This workflow automates the release process by:
+
+- **Version Detection**: Automatically detects version changes in your package
+- **Tag Management**: Creates and pushes version tags when releases are needed
+- **Release Creation**: Generates GitHub releases with auto-generated notes
+- **Smart Filtering**: Only releases when appropriate based on branch and
+  version type
+- **Multi-Language Support**: Supports both Go and Python projects
+- **Slack Integration**: Notifies Slack channels for stable releases
+
+## Features
+
+### Intelligent Release Logic
+
+The workflow implements smart release logic:
+
+- ✅ **Dev versions** (alpha, beta, rc, dev, pre, a, b) are released from
+  **feature branches**
+- ✅ **Stable versions** are released from the **main branch** (`develop`)
+- ❌ **Stable versions** are **NOT** released from feature branches
+- ❌ **Dev versions** are **NOT** released from the main branch
+- ❌ **No release** if version file hasn't changed
+- ❌ **No release** if the version tag already exists
+
+### Supported Languages
+
+- **Python**: Uses `hatch` to determine version from `pyproject.toml`
+- **Go**: Reads version from a `VERSION` file
+
+## Usage
+
+To use this workflow in your repository, create a workflow file (e.g.,
+`.github/workflows/release.yml`) in your project:
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [develop, "feature/*"]
+
+jobs:
+  release:
+    uses: nextmv-io/release/.github/workflows/release.yml@develop
+    with:
+      BRANCH: ${{ github.ref_name }}
+      REPOSITORY: your-repo-name
+      LANGUAGE: python  # or 'go'
+      PACKAGE_NAME: your-package-name
+      PACKAGE_LOCATION: .  # or path to your package
+      VERSION_FILE: __about__.py  # or VERSION for Go
+    secrets: inherit
+```
+
+### Example: Python Project (nextpipe)
+
+```yaml
+jobs:
+  release:
+    uses: nextmv-io/release/.github/workflows/release.yml@develop
+    with:
+      BRANCH: ${{ github.ref_name }}
+      REPOSITORY: nextpipe
+      LANGUAGE: python
+      PACKAGE_NAME: nextpipe
+      PACKAGE_LOCATION: .
+      VERSION_FILE: __about__.py
+    secrets: inherit
+```
+
+### Example: Go Project
+
+```yaml
+jobs:
+  release:
+    uses: nextmv-io/release/.github/workflows/release.yml@develop
+    with:
+      BRANCH: ${{ github.ref_name }}
+      REPOSITORY: my-go-project
+      LANGUAGE: go
+      PACKAGE_NAME: my-go-project
+      PACKAGE_LOCATION: .
+      VERSION_FILE: VERSION
+    secrets: inherit
+```
+
+## Input Parameters
+
+| Parameter | Required | Description | Example |
+|-----------|----------|-------------|---------|
+| `BRANCH` | ✅ | The branch that triggered the workflow | `${{ github.ref_name }}` |
+| `REPOSITORY` | ✅ | The repository name | `nextpipe` |
+| `LANGUAGE` | ✅ | The programming language (`python` or `go`) | `python` |
+| `PACKAGE_NAME` | ✅ | The name of the package to release | `nextpipe` |
+| `PACKAGE_LOCATION` | ✅ | The location of the package to release | `.` or `packages/core` |
+| `VERSION_FILE` | ✅ | The file that contains the version | `__about__.py` or `VERSION` |
+
+## Outputs
+
+The workflow provides the following outputs:
+
+| Output | Description | Example |
+|--------|-------------|---------|
+| `VERSION` | The version of the package | `v1.2.3` |
+| `RELEASE_NEEDED` | Whether a release was created | `true` or `false` |
+| `SHOULD_NOTIFY_SLACK` | Whether Slack should be notified | `true` or `false` |
+
+## Required Secrets
+
+The following secrets must be available in your repository (typically inherited
+from the organization):
+
+- `SLACK_URL_MISSION_CONTROL`: Slack webhook URL for release notifications
+- `NEXTMVBOT_SSH_KEY`: SSH key for the nextmv-bot user
+- `NEXTMVBOT_SIGNING_KEY`: GPG signing key for the nextmv-bot user
+
+## Version File Requirements
+
+### Python Projects
+
+For Python projects, the workflow uses `hatch version` to determine the
+version. Ensure your `pyproject.toml` is properly configured:
+
+```toml
+[project]
+dynamic = ["version"]
+
+[tool.hatch.version]
+path = "your_package/__about__.py"
+```
+
+### Go Projects
+
+For Go projects, create a `VERSION` file in your repository root containing
+just the version number:
+
+```
+1.2.3
+```
+
+## Workflow Behavior
+
+1. **Setup**: Configures git with bot credentials and clones the repository
+2. **Language Setup**: Installs language-specific dependencies (Python/Go)
+3. **Change Detection**: Uses path filters to detect if the version file
+   changed
+4. **Version Extraction**: Reads the version from the appropriate file
+5. **Release Logic**: Determines if a release is needed based on the rules
+   above
+6. **Tag & Release**: Creates the git tag and GitHub release if needed
+7. **Outputs**: Sets workflow outputs for downstream jobs
+
+## Integration with Other Workflows
+
+You can use the workflow outputs in subsequent jobs:
+
+```yaml
+jobs:
+  release:
+    uses: nextmv-io/release/.github/workflows/release.yml@develop
+    with:
+      # ... your inputs
+    secrets: inherit
+
+  notify:
+    needs: release
+    if: needs.release.outputs.SHOULD_NOTIFY_SLACK == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify team
+        run: echo "Released version ${{ needs.release.outputs.VERSION }}"
+```
+
+## Troubleshooting
+
+### Release Not Created
+
+Check that:
+
+- Your version file has actually changed in the commit
+- You're not trying to release a stable version from a feature branch
+- You're not trying to release a dev version from the main branch
+- The version tag doesn't already exist
+
+### Permission Issues
+
+Ensure your repository has the required secrets and the workflow has
+appropriate permissions for creating releases and tags.


### PR DESCRIPTION
# Description

Introduces two reusable workflows to be used by all repos across the org that release packages:

* Release workflow for tagging, releasing, and deciding whether to publish a release.
* Notification workflow for notifying to slack.

Unfortunately, PyPI does not support reusable workflows, so we could not include PyPI publishing in the release workflow. This is something I ran into as the original design was to have everything in a single workflow.