### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,13 +101,13 @@ jobs:
 
       - name: python - set up
         if: ${{ inputs.LANGUAGE == 'python' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: go - set up
         if: ${{ inputs.LANGUAGE == 'go' }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -144,7 +144,7 @@ jobs:
 
       - name: filter changed directories
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         with:
           filters: .github/filters.yml
           working-directory: ./${{ inputs.REPOSITORY }}


### PR DESCRIPTION
# Description

Pins all workflow actions to their latest version via shas for improved security (avoiding supply chain attacks).

## Changes

- `actions/setup-python`: `v5` → `v6.2.0` (`a309ff8b426b...`)
- `actions/setup-go`: `v5` → `v6.4.0` (`4a3601121dd0...`)
- `dorny/paths-filter`: `v3` → `v4.0.1` (`fbd0ab8f3e69...`)
